### PR TITLE
Add support to Docker images for ARM platforms

### DIFF
--- a/Dockerfile.full
+++ b/Dockerfile.full
@@ -33,10 +33,12 @@ RUN cd 3proxy &&\
  strip bin/TrafficPlugin.ld.so &&\
  strip bin/PCREPlugin.ld.so &&\
  strip bin/TransparentPlugin.ld.so &&\
- strip bin/SSLPlugin.ld.so
+ strip bin/SSLPlugin.ld.so &&\
+ mkdir /usr/local/lib/3proxy &&\
+ cp "/lib/`gcc -dumpmachine`"/libdl.so.* /usr/local/lib/3proxy/
 
 FROM busybox:glibc
-COPY --from=buildenv /lib/x86_64-linux-gnu/libdl.so.* /lib/
+COPY --from=buildenv /usr/local/lib/3proxy/libdl.so.* /lib/
 COPY --from=buildenv 3proxy/bin/3proxy /bin/
 COPY --from=buildenv 3proxy/bin/*.ld.so /usr/local/3proxy/libexec/
 RUN mkdir /usr/local/3proxy/logs &&\
@@ -50,6 +52,4 @@ RUN mkdir /usr/local/3proxy/logs &&\
  echo chroot /usr/local/3proxy 65535 65535 >/etc/3proxy/3proxy.cfg &&\
  echo include /conf/3proxy.cfg >>/etc/3proxy/3proxy.cfg &&\
  chmod 440  /etc/3proxy/3proxy.cfg
-
-
 CMD ["/bin/3proxy", "/etc/3proxy/3proxy.cfg"]

--- a/Dockerfile.minimal
+++ b/Dockerfile.minimal
@@ -25,18 +25,17 @@
 
 
 FROM gcc AS buildenv
-COPY . /3proxy
-RUN cd /3proxy &&\
- echo "">>Makefile.Linux&&\
- echo LDFLAGS = -fPIE -O2 -fno-strict-aliasing -pthread >>Makefile.Linux&&\
- echo PLUGINS = >>Makefile.Linux&&\
- echo LIBS = >>Makefile.Linux&&\
- echo CFLAGS = -g  -fPIC -O2 -fno-strict-aliasing -c -pthread -DWITHSPLICE -D_GNU_SOURCE -DGETHOSTBYNAME_R -D_THREAD_SAFE -D_REENTRANT -DNOODBC -DWITH_STD_MALLOC -DFD_SETSIZE=4096 -DWITH_POLL -DWITH_NETFILTER -DNOPLUGINS >>Makefile.Linux&&\
- make -f Makefile.Linux&&\
+COPY . 3proxy
+RUN cd 3proxy &&\
+ echo "">>Makefile.Linux &&\
+ echo LDFLAGS = -fPIE -O2 -fno-strict-aliasing -pthread >>Makefile.Linux &&\
+ echo PLUGINS = >>Makefile.Linux &&\
+ echo LIBS = >>Makefile.Linux &&\
+ echo CFLAGS = -g  -fPIC -O2 -fno-strict-aliasing -c -pthread -DWITHSPLICE -D_GNU_SOURCE -DGETHOSTBYNAME_R -D_THREAD_SAFE -D_REENTRANT -DNOODBC -DWITH_STD_MALLOC -DFD_SETSIZE=4096 -DWITH_POLL -DWITH_NETFILTER -DNOPLUGINS >>Makefile.Linux &&\
+ make -f Makefile.Linux &&\
  strip bin/3proxy
  
-
 FROM busybox:glibc
-COPY --from=buildenv /3proxy/bin/3proxy /bin/3proxy
+COPY --from=buildenv 3proxy/bin/3proxy /bin/3proxy
 RUN mkdir /run && chmod 555 /run
 CMD ["/bin/3proxy"]


### PR DESCRIPTION
Update Dockerfiles 

- Remove hardcoded "/lib/x86_64-linux-gnu" path
- Move libdl.so.* to a common location
- Format code to keep consistency between dockerfiles