### PR TITLE
Fix reading domain name of incorrect length

### DIFF
--- a/src/auth.c
+++ b/src/auth.c
@@ -195,8 +195,13 @@ int clientnegotiate(struct chain * redir, struct clientparam * param, struct soc
 				    break;
 			    return 59;
 			case 3:
-			    if (sockgetlinebuf(param, SERVER, buf, 1, EOF, conf.timeouts[CHAIN_TO]) != 1) return 59;
-			    if (sockgetlinebuf(param, SERVER, buf, (unsigned)(buf[0]+2), EOF, conf.timeouts[CHAIN_TO]) != (unsigned)(buf[0]+2)) return 59;
+			    if (sockgetlinebuf(param, SERVER, buf, 1, EOF, conf.timeouts[CHAIN_TO]) != 1)
+				    return 59;
+				
+			    const unsigned hostname_length = buf[0];
+					
+			    if (sockgetlinebuf(param, SERVER, buf, hostname_length + 2, EOF, conf.timeouts[CHAIN_TO]) != hostname_length + 2)
+				    return 59;
 			    break;
 			case 4:
 			    if (sockgetlinebuf(param, SERVER, buf, 18, EOF, conf.timeouts[CHAIN_TO]) == 18)


### PR DESCRIPTION
Fixed a bug that causes SOCKS 5 proxy 59 error due to reading hostname of incorrect length.