### PR TITLE
Add support for TCP_FASTOPEN_CONNECT and TCP_FASTOPEN socket options

### DIFF
--- a/src/proxymain.c
+++ b/src/proxymain.c
@@ -125,6 +125,12 @@ struct socketoptions sockopts[] = {
 #ifdef IP_TRANSPARENT
 	{IP_TRANSPARENT, "IP_TRANSPARENT"},
 #endif
+#ifdef TCP_FASTOPEN
+	{TCP_FASTOPEN, "TCP_FASTOPEN"},
+#endif
+#ifdef TCP_FASTOPEN_CONNECT
+	{TCP_FASTOPEN_CONNECT, "TCP_FASTOPEN_CONNECT"},
+#endif
 	{0, NULL}
 };
 


### PR DESCRIPTION
These options are available in Linux. TCP_FASTOPEN allows making a listening socket use TFO and to make outgoing connections use TFO there is TCP_FASTOPEN_CONNECT.