### PR TITLE
Fix plugin declarations of hashindex and nametohash

### DIFF
--- a/src/plugins.c
+++ b/src/plugins.c
@@ -11,8 +11,8 @@
 unsigned bandlimitfunc(struct clientparam *param, unsigned nbytesin, unsigned nbytesout);
 void trafcountfunc(struct clientparam *param);
 int checkACL(struct clientparam * param);
-void nametohash(const unsigned char * name, unsigned char *hash);
-unsigned hashindex(const unsigned char* hash);
+void nametohash(const unsigned char * name, unsigned char *hash, unsigned char *rnd);
+unsigned hashindex(struct hashtable *ht, const unsigned char* hash);
 void decodeurl(unsigned char *s, int allowcr);
 int parsestr (unsigned char *str, unsigned char **argm, int nitems, unsigned char ** buff, int *inbuf, int *bufsize);
 struct ace * make_ace (int argc, unsigned char ** argv);

--- a/src/structures.h
+++ b/src/structures.h
@@ -753,8 +753,8 @@ struct pluginlink {
 	int (*ACLMatches)(struct ace* acentry, struct clientparam * param);
 	int (*alwaysauth)(struct clientparam * param);
 	int (*checkACL)(struct clientparam * param);
-	void (*nametohash)(const unsigned char * name, unsigned char *hash);
-	unsigned (*hashindex)(const unsigned char* hash);
+	void (*nametohash)(const unsigned char * name, unsigned char *hash, unsigned char *rnd);
+	unsigned (*hashindex)(struct hashtable *ht, const unsigned char* hash);
 	unsigned char* (*en64)(const unsigned char *in, unsigned char *out, int inlen);
 	int (*de64)(const unsigned char *in, unsigned char *out, int maxlen);
 	void (*tohex)(unsigned char *in, unsigned char *out, int len);


### PR DESCRIPTION
Plugins using these would fail to provide the required arguments.