### PR TITLE
Extend SOCKS for AnyIP utilization

### DIFF
--- a/man/socks.8
+++ b/man/socks.8
@@ -42,6 +42,16 @@ of IP-IP NAT (will not work for PAT)
 Internal address. IP address proxy accepts connections to.
 By default connection to any interface is accepted. It\'s usually unsafe.
 .TP
+.B -k
+External address given by
+.B -e
+is ignored and the internal address or generally the address client conected to is used instead.
+This allows to utilize AnyIP Linux feature when
+.B -i0.0.0.0
+or in case of IPv6
+.B -i::
+is set. Not available for Windows platform.
+.TP
 .B -p
 Port. Port proxy listens for incoming connections. Default is 1080.
 .TP

--- a/src/common.c
+++ b/src/common.c
@@ -531,6 +531,11 @@ int doconnect(struct clientparam * param){
 	setopts(param->remsock, param->srv->srvsockopts);
 
 	param->srv->so._setsockopt(param->sostate, param->remsock, SOL_SOCKET, SO_LINGER, (char *)&lg, sizeof(lg));
+
+	if (param->srv->keepip) {
+		int opt = 1;
+		param->srv->so._setsockopt(param->sostate, param->remsock, SOL_IP, IP_FREEBIND, (char *)&opt, sizeof(int));
+	}
 #ifdef REUSE
 	{
 		int opt;

--- a/src/structures.h
+++ b/src/structures.h
@@ -479,6 +479,7 @@ struct srvparam {
 	int paused, version;
 	int singlepacket;
 	int usentlm;
+	int keepip;
 	int needuser;
 	int silent;
 	int transparent;


### PR DESCRIPTION
Introduce '-k' parameter that overwrites the '-e' parameter (if given) and uses the IP for the external connection that corresponds to the current client connection. The benefit arises when the parameter '-i0.0.0.0' or '-i::' in case of IPv6 is set. This allows the entire range configured as local on the system to receive connections and establish connections to the target server using the IP address to which the client connected.
Note: This feature is not applicable for Windows.