### PR TITLE
Fix race condition in make install on linux

### DIFF
--- a/Makefile.Linux
+++ b/Makefile.Linux
@@ -103,7 +103,7 @@ install-chroot-dir:
 	$(INSTALL_BIN) -d $(CHROOTDIR)/libexec
 	chmod -R o-rwx $(CHROOTDIR)
 
-install-etc-default-config:
+install-etc-default-config: install-chroot-dir
 	if [ ! -d $(INSTALL_CFG_DEST) ]; then \
 	   ln -s $(CHROOTREL)/conf $(INSTALL_CFG_DEST); \
 	   $(INSTALL_BIN) $(INSTALL_CFG) $(ETCDIR)/3proxy.cfg; \


### PR DESCRIPTION
Since INSTALL_CFG_DEST is a symlink we also need to make sure that the target always exists before installing anything to it.

Fixes f860ea9e5446 Install chrooted configuration with make install on linux