### PR TITLE
cmake: use targets for plugins installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -620,14 +620,6 @@ foreach(PROXY_NAME proxy socks pop3p smtpp ftppr tcppm udppm tlspr)
     endif()
 endforeach()
 
-# Plugin output directory
-set(PLUGIN_OUTPUT_DIR ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
-if(WIN32)
-    set(PLUGIN_SUFFIX ".dll")
-else()
-    set(PLUGIN_SUFFIX ".ld.so")
-endif()
-
 # Include plugin definitions
 include(cmake/plugins.cmake)
 
@@ -661,16 +653,17 @@ foreach(PROXY_NAME proxy socks pop3p smtpp ftppr tcppm udppm tlspr)
 endforeach()
 
 # Install plugins
-file(GLOB PLUGINFILES "${PLUGIN_OUTPUT_DIR}/*${PLUGIN_SUFFIX}")
+get_property(PLUGINTARGETS GLOBAL PROPERTY 3PROXY_PLUGIN_TARGETS)
+
 if(WIN32)
-    install(FILES
-        ${PLUGINFILES}
-        DESTINATION ${CMAKE_INSTALL_BINDIR}
+    install(TARGETS
+        ${PLUGINTARGETS}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     )
 else()
-    install(FILES
-        ${PLUGINFILES}
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/3proxy
+    install(TARGETS
+        ${PLUGINTARGETS}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/3proxy
     )
 endif()
 

--- a/cmake/plugins.cmake
+++ b/cmake/plugins.cmake
@@ -20,6 +20,8 @@ function(add_3proxy_plugin PLUGIN_NAME)
 
     add_library(${PLUGIN_NAME} SHARED ${PLUGIN_SOURCES})
 
+    set_property(GLOBAL APPEND PROPERTY 3PROXY_PLUGIN_TARGETS ${PLUGIN_NAME})
+
     set_target_properties(${PLUGIN_NAME} PROPERTIES
         PREFIX ""
         SUFFIX ${PLUGIN_SUFFIX}


### PR DESCRIPTION
using file(GLOB) could install plugins from the wrong location, use targets instead to get the correct output path

@z3APA3A, I think targets are more robust. SO are installed in libdir/3proxy with this PR:
usr/lib64/3proxy/FilePlugin.ld.so                                                                                               
usr/lib64/3proxy/PamAuth.ld.so                              
usr/lib64/3proxy/StringsPlugin.ld.so                       
usr/lib64/3proxy/TrafficPlugin.ld.so                                                                                            
usr/lib64/3proxy/TransparentPlugin.ld.so

I can't test for windows but hopefully it's fine too.