### PR TITLE
Add per-socket local port ranges

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ option(3PROXY_USE_SPLICE "Build Linux splice() support, slower than read/write f
 option(3PROXY_USE_POLL "Use poll() instead of select() (Unix only)" ON)
 option(3PROXY_USE_WSAPOLL "Use WSAPoll instead of select() (Windows only)" ON)
 option(3PROXY_USE_NETFILTER "Enable Linux netfilter support (Linux only)" ON)
+option(3PROXY_USE_LOCAL_PORT_RANGE "Enable per-connection local port ranges (Linux 6.3+ only)" ON)
 option(3PROXY_USE_UNIX_SOCKETS "Enable Unix domain socket support (Unix only)" ON)
 
 if(NOT WIN32 AND NOT APPLE)
@@ -183,6 +184,10 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
 
     if(3PROXY_USE_NETFILTER)
         add_compile_definitions(WITH_NETFILTER)
+    endif()
+
+    if(3PROXY_USE_LOCAL_PORT_RANGE)
+        add_compile_definitions(WITH_LOCAL_PORT_RANGE)
     endif()
 
     if(3PROXY_USE_UNIX_SOCKETS)

--- a/Makefile.Linux
+++ b/Makefile.Linux
@@ -25,6 +25,10 @@ LDFLAGS += -fno-strict-aliasing -pthread
 # makefile, including the += above and the STATIC/LIBSTATIC handling below.
 CFLAGS += $(EXTRA_CFLAGS)
 LDFLAGS += $(EXTRA_LDFLAGS)
+LOCAL_PORT_RANGE ?= true
+ifeq ($(LOCAL_PORT_RANGE),true)
+    CFLAGS += -DWITH_LOCAL_PORT_RANGE
+endif
 DLFLAGS ?= -shared
 DLSUFFICS = .ld.so
 # -lpthreads may be reuqired on some platforms instead of -pthreads

--- a/man/3proxy.cfg.5
+++ b/man/3proxy.cfg.5
@@ -176,6 +176,9 @@ listen on given local HOST:port for incoming connections instead of making remot
 .B -r\fIHOST\fB:\fIport\fR
 connect to given remote HOST:port instead of listening local connection on -p or default port. Can be used with another 3proxy service running -R option for connect back functionality. Most commonly used with proxy or socks. HOST can be given as IP or hostname, useful in case of dynamic DNS.
 .br
+.B -Tr\fIFIRST\fB-\fILAST\fR, -Ur\fIFIRST\fB-\fILAST\fR, -UAr\fIFIRST\fB-\fILAST\fR
+(Linux) use the inclusive local ephemeral port range FIRST-LAST for outgoing IPv4 TCP (-Tr) or UDP (-Ur) sockets of this service. -UAr applies only to the UDP relay socket returned to a SOCKS5 UDP ASSOCIATE client. Use it when this port range must be forwarded by NAT and allowed by a firewall. Requires kernel support for IP_LOCAL_PORT_RANGE (Linux 6.3 or newer). The option is applied before bind(2); no system-wide sysctl is changed. For example, \fBsocks -p1080 -Ur20000-30000 -UAr30000-31000\fR.
+.br
 .B -oc\fIOPTIONS\fB, -os\fIOPTIONS\fB, -ol\fIOPTIONS\fB, -or\fIOPTIONS\fB, -oR\fIOPTIONS\fR
 options for proxy-to-client (\fB-oc\fR), proxy-to-server (\fB-os\fR), proxy listening (\fB-ol\fR), connect back client (\fB-or\fR), connect back listening (\fB-oR\fR) sockets.
 Options like TCP_CORK, TCP_NODELAY, TCP_DEFER_ACCEPT, TCP_QUICKACK, TCP_TIMESTAMPS, TCP_FASTOPEN, SO_REUSEADDR, SO_REUSEPORT, SO_EXCLUSIVEADDRUSE, SO_PORT_SCALABILITY, SO_REUSE_UNICASTPORT, SO_KEEPALIVE, SO_DONTROUTE may be supported depending on OS.

--- a/man/3proxy.cfg.5
+++ b/man/3proxy.cfg.5
@@ -878,7 +878,7 @@ with probability of 0.7) for outgoing web connections. Chains are only applied t
 .br
  type is one of:
 .br
-\fBextip\fR does not actually redirect the request; it sets the external address for this request to \fI<ip>\fR. It can be chained with another parent type. It's useful to set the external IP based on ACL or make it random. When built with \fBWITH_LOCAL_PORT_RANGE\fR on Linux 6.3 or newer, \fI<port>\fR may be an inclusive IPv4 local port range \fIFIRST-LAST\fR. The range is applied to outgoing sockets for requests matching this parent; DNS resolver traffic is not affected. For example, \fBparent 1000 extip 192.0.2.10 20000-30000\fR.
+\fBextip\fR does not actually redirect the request; it sets the external address for this request to \fI<ip>\fR. It can be chained with another parent type. It's useful to set the external IP based on ACL or make it random. Its \fI<port>\fR argument is optional and defaults to 0. When built with \fBWITH_LOCAL_PORT_RANGE\fR on Linux 6.3 or newer, \fI<port>\fR may be an inclusive IPv4 local port range \fIFIRST-LAST\fR. The range is applied to outgoing sockets for requests matching this parent; DNS resolver traffic is not affected. For example, \fBparent 1000 extip 192.0.2.10 20000-30000\fR.
 .br
  \fBtcp\fR simply redirect connection. TCP is always last in chain. This type of proxy is a simple TCP redirection, it does not support parent authentication.
 .br

--- a/man/3proxy.cfg.5
+++ b/man/3proxy.cfg.5
@@ -176,9 +176,6 @@ listen on given local HOST:port for incoming connections instead of making remot
 .B -r\fIHOST\fB:\fIport\fR
 connect to given remote HOST:port instead of listening local connection on -p or default port. Can be used with another 3proxy service running -R option for connect back functionality. Most commonly used with proxy or socks. HOST can be given as IP or hostname, useful in case of dynamic DNS.
 .br
-.B -Tr\fIFIRST\fB-\fILAST\fR, -Ur\fIFIRST\fB-\fILAST\fR, -UAr\fIFIRST\fB-\fILAST\fR
-(Linux) use the inclusive local ephemeral port range FIRST-LAST for outgoing IPv4 TCP (-Tr) or UDP (-Ur) sockets of this service. -UAr applies only to the UDP relay socket returned to a SOCKS5 UDP ASSOCIATE client. Use it when this port range must be forwarded by NAT and allowed by a firewall. Requires kernel support for IP_LOCAL_PORT_RANGE (Linux 6.3 or newer). The option is applied before bind(2); no system-wide sysctl is changed. For example, \fBsocks -p1080 -Ur20000-30000 -UAr30000-31000\fR.
-.br
 .B -oc\fIOPTIONS\fB, -os\fIOPTIONS\fB, -ol\fIOPTIONS\fB, -or\fIOPTIONS\fB, -oR\fIOPTIONS\fR
 options for proxy-to-client (\fB-oc\fR), proxy-to-server (\fB-os\fR), proxy listening (\fB-ol\fR), connect back client (\fB-or\fR), connect back listening (\fB-oR\fR) sockets.
 Options like TCP_CORK, TCP_NODELAY, TCP_DEFER_ACCEPT, TCP_QUICKACK, TCP_TIMESTAMPS, TCP_FASTOPEN, SO_REUSEADDR, SO_REUSEPORT, SO_EXCLUSIVEADDRUSE, SO_PORT_SCALABILITY, SO_REUSE_UNICASTPORT, SO_KEEPALIVE, SO_DONTROUTE may be supported depending on OS.
@@ -881,7 +878,7 @@ with probability of 0.7) for outgoing web connections. Chains are only applied t
 .br
  type is one of:
 .br
- \fBextip\fR does not actually redirect the request; it sets the external address for this request to \fI<ip>\fR. It can be chained with another parent type. It's useful to set the external IP based on ACL or make it random.
+\fBextip\fR does not actually redirect the request; it sets the external address for this request to \fI<ip>\fR. It can be chained with another parent type. It's useful to set the external IP based on ACL or make it random. When built with \fBWITH_LOCAL_PORT_RANGE\fR on Linux 6.3 or newer, \fI<port>\fR may be an inclusive IPv4 local port range \fIFIRST-LAST\fR. The range is applied to outgoing sockets for requests matching this parent; DNS resolver traffic is not affected. For example, \fBparent 1000 extip 192.0.2.10 20000-30000\fR.
 .br
  \fBtcp\fR simply redirect connection. TCP is always last in chain. This type of proxy is a simple TCP redirection, it does not support parent authentication.
 .br

--- a/src/common.c
+++ b/src/common.c
@@ -52,6 +52,11 @@ int switch_ns(struct srvparam *srv, int target_fd) {
 }
 #endif
 
+#ifdef __linux__
+#ifndef IP_LOCAL_PORT_RANGE
+#define IP_LOCAL_PORT_RANGE 51
+#endif
+#endif
 
 char * copyright = COPYRIGHT;
 
@@ -722,6 +727,7 @@ int doconnect(struct clientparam * param){
 	}
 	*SAPORT(&param->sinsl) = 0;
 	setopts(param->remsock, param->srv->srvsockopts);
+	if(set_local_port_range(param->srv, param->remsock, (struct sockaddr *)&param->sinsl, LOCAL_PORT_RANGE_TCP)) return 12;
 
 	param->srv->so._setsockopt(param->sostate, param->remsock, SOL_SOCKET, SO_LINGER, (char *)&lg, sizeof(lg));
 #if defined SO_BINDTODEVICE
@@ -765,6 +771,24 @@ int doconnect(struct clientparam * param){
     if(action != PASS) return 19;
  }
  return 0;
+}
+
+int set_local_port_range(struct srvparam *srv, SOCKET sock, const struct sockaddr *sa, int range_type){
+#ifdef __linux__
+	uint32_t range = range_type == LOCAL_PORT_RANGE_TCP ? srv->tcp_local_port_range :
+		range_type == LOCAL_PORT_RANGE_UDP ? srv->udp_local_port_range : srv->udp_associate_port_range;
+
+	if(range && sa->sa_family == AF_INET &&
+	   ((const struct sockaddr_in *)sa)->sin_port == 0 &&
+	   srv->so._setsockopt(srv->so.state, sock, IPPROTO_IP, IP_LOCAL_PORT_RANGE,
+		(char *)&range, sizeof(range))) return -1;
+#else
+	(void)srv;
+	(void)sock;
+	(void)sa;
+	(void)range_type;
+#endif
+	return 0;
 }
 
 int scanaddr(const unsigned char *s, uint32_t * ip, uint32_t * mask) {

--- a/src/common.c
+++ b/src/common.c
@@ -52,7 +52,7 @@ int switch_ns(struct srvparam *srv, int target_fd) {
 }
 #endif
 
-#ifdef __linux__
+#ifdef WITH_LOCAL_PORT_RANGE
 #ifndef IP_LOCAL_PORT_RANGE
 #define IP_LOCAL_PORT_RANGE 51
 #endif
@@ -727,7 +727,9 @@ int doconnect(struct clientparam * param){
 	}
 	*SAPORT(&param->sinsl) = 0;
 	setopts(param->remsock, param->srv->srvsockopts);
-	if(set_local_port_range(param->srv, param->remsock, (struct sockaddr *)&param->sinsl, LOCAL_PORT_RANGE_TCP)) return 12;
+#ifdef WITH_LOCAL_PORT_RANGE
+	if(set_local_port_range(param, param->remsock, (struct sockaddr *)&param->sinsl)) return 12;
+#endif
 
 	param->srv->so._setsockopt(param->sostate, param->remsock, SOL_SOCKET, SO_LINGER, (char *)&lg, sizeof(lg));
 #if defined SO_BINDTODEVICE
@@ -773,23 +775,15 @@ int doconnect(struct clientparam * param){
  return 0;
 }
 
-int set_local_port_range(struct srvparam *srv, SOCKET sock, const struct sockaddr *sa, int range_type){
-#ifdef __linux__
-	uint32_t range = range_type == LOCAL_PORT_RANGE_TCP ? srv->tcp_local_port_range :
-		range_type == LOCAL_PORT_RANGE_UDP ? srv->udp_local_port_range : srv->udp_associate_port_range;
-
-	if(range && sa->sa_family == AF_INET &&
+#ifdef WITH_LOCAL_PORT_RANGE
+int set_local_port_range(struct clientparam *param, SOCKET sock, const struct sockaddr *sa){
+	if(param->local_port_range && sa->sa_family == AF_INET &&
 	   ((const struct sockaddr_in *)sa)->sin_port == 0 &&
-	   srv->so._setsockopt(srv->so.state, sock, IPPROTO_IP, IP_LOCAL_PORT_RANGE,
-		(char *)&range, sizeof(range))) return -1;
-#else
-	(void)srv;
-	(void)sock;
-	(void)sa;
-	(void)range_type;
-#endif
+	   param->srv->so._setsockopt(param->srv->so.state, sock, IPPROTO_IP, IP_LOCAL_PORT_RANGE,
+		(char *)&param->local_port_range, sizeof(param->local_port_range))) return -1;
 	return 0;
 }
+#endif
 
 int scanaddr(const unsigned char *s, uint32_t * ip, uint32_t * mask) {
 	unsigned d1, d2, d3, d4, m;

--- a/src/conf.c
+++ b/src/conf.c
@@ -814,6 +814,11 @@ static int h_parent(int argc, unsigned char **argv){
 		free(chains);
 		return(4);
 	}
+	if(argc < 5 && chains->type != R_EXTIP) {
+		fprintf(stderr, "Chaining error: port is required for parent type %s\n", argv[2]);
+		free(chains);
+		return(3);
+	}
 #ifdef WITH_UN
 	if(!strncmp((char *)argv[3], "unix:", 5)){
 	    make_un(argv[3] + 5, (struct sockaddr_un*)&chains->addr);
@@ -838,7 +843,7 @@ static int h_parent(int argc, unsigned char **argv){
 		*cidr = '/';
 		chains->cidr = atoi(cidr + 1);
 	}
-	{
+	if(argc > 4) {
 		char *end;
 		unsigned long port;
 
@@ -1741,7 +1746,7 @@ struct commands commandhandlers[]={
 	{NULL, "system", h_system, 2, 2},
 	{NULL, "pidfile", h_pidfile, 2, 2},
 	{NULL, "monitor", h_monitor, 2, 2},
-	{NULL, "parent", h_parent, 5, 0},
+	{NULL, "parent", h_parent, 4, 0},
 	{NULL, "allow", h_ace, 1, 0},
 	{NULL, "deny", h_ace, 1, 0},
 	{NULL, "redirect", h_ace, 3, 0},

--- a/src/conf.c
+++ b/src/conf.c
@@ -838,7 +838,34 @@ static int h_parent(int argc, unsigned char **argv){
 		*cidr = '/';
 		chains->cidr = atoi(cidr + 1);
 	}
-	*SAPORT(&chains->addr) = htons((uint16_t)atoi((char *)argv[4]));
+	{
+		char *end;
+		unsigned long port;
+
+		errno = 0;
+		port = strtoul((char *)argv[4], &end, 10);
+#ifdef WITH_LOCAL_PORT_RANGE
+		if(chains->type == R_EXTIP && *end == '-') {
+			unsigned long last;
+
+			errno = 0;
+			last = strtoul(end + 1, &end, 10);
+			if(errno || *end || !port || !last || port > last || last > 65535) {
+				free(chains->exthost);
+				free(chains);
+				return 3;
+			}
+			chains->local_port_range = ((uint32_t)last << 16) | (uint32_t)port;
+			port = 0;
+		}
+#endif
+		if(errno || *end || port > 65535) {
+			free(chains->exthost);
+			free(chains);
+			return 3;
+		}
+		*SAPORT(&chains->addr) = htons((uint16_t)port);
+	}
 	switch(chains->type){
 	    case R_POP3:
 	    case R_SMTP:

--- a/src/dnspr.c
+++ b/src/dnspr.c
@@ -149,6 +149,10 @@ void * dnsprchild(struct clientparam* param) {
 	}
 	memset(&param->sinsl, 0, sizeof(param->sinsl));
 	*SAFAMILY(&param->sinsl) = *SAFAMILY(&nservers[0].addr);
+	if(set_local_port_range(param->srv, param->remsock, (struct sockaddr *)&param->sinsl,
+		nservers[0].usetcp ? LOCAL_PORT_RANGE_TCP : LOCAL_PORT_RANGE_UDP)) {
+		RETURN(819);
+	}
 	if(param->srv->so._bind(param->sostate, param->remsock,(struct sockaddr *)&param->sinsl,SASIZE(&param->sinsl))) {
 		RETURN(819);
 	}
@@ -222,4 +226,3 @@ CLEANRET:
 #endif
  return (NULL);
 }
-

--- a/src/dnspr.c
+++ b/src/dnspr.c
@@ -149,10 +149,6 @@ void * dnsprchild(struct clientparam* param) {
 	}
 	memset(&param->sinsl, 0, sizeof(param->sinsl));
 	*SAFAMILY(&param->sinsl) = *SAFAMILY(&nservers[0].addr);
-	if(set_local_port_range(param->srv, param->remsock, (struct sockaddr *)&param->sinsl,
-		nservers[0].usetcp ? LOCAL_PORT_RANGE_TCP : LOCAL_PORT_RANGE_UDP)) {
-		RETURN(819);
-	}
 	if(param->srv->so._bind(param->sostate, param->remsock,(struct sockaddr *)&param->sinsl,SASIZE(&param->sinsl))) {
 		RETURN(819);
 	}

--- a/src/ftppr.c
+++ b/src/ftppr.c
@@ -121,6 +121,7 @@ void * ftpprchild(struct clientparam* param) {
 		}
 		if ((clidatasock=socket(SASOCK(&param->sincl), SOCK_STREAM, IPPROTO_TCP)) == INVALID_SOCKET) {RETURN(821);}
 		*SAPORT(&param->sincl) = 0;
+		if(set_local_port_range(param->srv, clidatasock, (struct sockaddr *)&param->sincl, LOCAL_PORT_RANGE_TCP)){RETURN(822);}
 		if(param->srv->so._bind(param->sostate, clidatasock, (struct sockaddr *)&param->sincl, SASIZE(&param->sincl))){RETURN(822);}
 		if (pasv) {
 			if(param->srv->so._listen(param->sostate, clidatasock, 1)) {RETURN(823);}

--- a/src/ftppr.c
+++ b/src/ftppr.c
@@ -121,7 +121,9 @@ void * ftpprchild(struct clientparam* param) {
 		}
 		if ((clidatasock=socket(SASOCK(&param->sincl), SOCK_STREAM, IPPROTO_TCP)) == INVALID_SOCKET) {RETURN(821);}
 		*SAPORT(&param->sincl) = 0;
-		if(set_local_port_range(param->srv, clidatasock, (struct sockaddr *)&param->sincl, LOCAL_PORT_RANGE_TCP)){RETURN(822);}
+#ifdef WITH_LOCAL_PORT_RANGE
+		if(set_local_port_range(param, clidatasock, (struct sockaddr *)&param->sincl)){RETURN(822);}
+#endif
 		if(param->srv->so._bind(param->sostate, clidatasock, (struct sockaddr *)&param->sincl, SASIZE(&param->sincl))){RETURN(822);}
 		if (pasv) {
 			if(param->srv->so._listen(param->sostate, clidatasock, 1)) {RETURN(823);}

--- a/src/proxy.h
+++ b/src/proxy.h
@@ -352,6 +352,10 @@ unsigned char * dologname (unsigned char *buf, unsigned char *name, const unsign
 int readconfig(FILE * fp);
 void initcommands(void);
 int connectwithpoll(struct clientparam *param, SOCKET sock, struct sockaddr *sa, SASIZETYPE size, int to);
+#define LOCAL_PORT_RANGE_TCP 1
+#define LOCAL_PORT_RANGE_UDP 2
+#define LOCAL_PORT_RANGE_UDP_ASSOCIATE 3
+int set_local_port_range(struct srvparam *srv, SOCKET sock, const struct sockaddr *sa, int range_type);
 
 
 uint32_t myrand(void);
@@ -433,4 +437,3 @@ extern char * ceargv[32];
 #define WEBBANNERS 35
 
 #endif
-

--- a/src/proxy.h
+++ b/src/proxy.h
@@ -352,10 +352,9 @@ unsigned char * dologname (unsigned char *buf, unsigned char *name, const unsign
 int readconfig(FILE * fp);
 void initcommands(void);
 int connectwithpoll(struct clientparam *param, SOCKET sock, struct sockaddr *sa, SASIZETYPE size, int to);
-#define LOCAL_PORT_RANGE_TCP 1
-#define LOCAL_PORT_RANGE_UDP 2
-#define LOCAL_PORT_RANGE_UDP_ASSOCIATE 3
-int set_local_port_range(struct srvparam *srv, SOCKET sock, const struct sockaddr *sa, int range_type);
+#ifdef WITH_LOCAL_PORT_RANGE
+int set_local_port_range(struct clientparam *param, SOCKET sock, const struct sockaddr *sa);
+#endif
 
 
 uint32_t myrand(void);

--- a/src/proxymain.c
+++ b/src/proxymain.c
@@ -345,6 +345,7 @@ int MODULEMAINFUNC (int argc, char** argv){
 	"\n"
 	" -iIP ip address or internal interface (clients are expected to connect)\n"
 	" -eIP ip address or external interface (outgoing connection will have this)\n"
+	" -TrFIRST-LAST, -UrFIRST-LAST, -UArFIRST-LAST Linux: local TCP, UDP or UDP ASSOCIATE ranges\n"
 	" -rHOST:PORT Use IP:port for connect back proxy instead of listen port\n"
 	" -RHOST:PORT Use PORT to listen connect back proxy connection to pass data to\n"
 	" -4 Use IPv4 for outgoing connections\n"
@@ -568,6 +569,35 @@ int MODULEMAINFUNC (int argc, char** argv){
 			srv.needuser = 0;
 			if(*(argv[i] + 2)) srv.needuser = atoi(argv[i] + 2);
 			break;
+		 case 'U':
+#ifdef __linux__
+			{
+				char *end;
+				const char *range_arg;
+				unsigned long first, last;
+				uint32_t *range;
+
+				if(argv[i][2] == 'r') {
+					range_arg = argv[i] + 3;
+					range = &srv.udp_local_port_range;
+				}
+				else if(argv[i][2] == 'A' && argv[i][3] == 'r') {
+					range_arg = argv[i] + 4;
+					range = &srv.udp_associate_port_range;
+				}
+				else { error = 1; break; }
+				errno = 0;
+				first = strtoul(range_arg, &end, 10);
+				if(errno || end == range_arg || *end != '-') { error = 1; break; }
+				errno = 0;
+				last = strtoul(end + 1, &end, 10);
+				if(errno || *end || !first || !last || first > last || last > 65535) { error = 1; break; }
+				*range = ((uint32_t)last << 16) | (uint32_t)first;
+			}
+#else
+			error = 1;
+#endif
+			break;
 		 case 'x':
 			srv.nostarttls = 1;
 			break;
@@ -590,7 +620,27 @@ int MODULEMAINFUNC (int argc, char** argv){
 			}
 			break;
 		 case 'T':
-			srv.transparent = 1;
+			if(!argv[i][2]) {
+				srv.transparent = 1;
+				break;
+			}
+#ifdef __linux__
+			{
+				char *end;
+				unsigned long first, last;
+
+				if(argv[i][2] != 'r') { error = 1; break; }
+				errno = 0;
+				first = strtoul(argv[i] + 3, &end, 10);
+				if(errno || end == argv[i] + 3 || *end != '-') { error = 1; break; }
+				errno = 0;
+				last = strtoul(end + 1, &end, 10);
+				if(errno || *end || !first || !last || first > last || last > 65535) { error = 1; break; }
+				srv.tcp_local_port_range = ((uint32_t)last << 16) | (uint32_t)first;
+			}
+#else
+			error = 1;
+#endif
 			break;
 		 case 'S':
 			srv.stacksize = atoi(argv[i]+2);
@@ -1797,5 +1847,3 @@ FILTER_ACTION handledatfltsrv(struct clientparam *cparam, unsigned char ** buf_p
 	}
 	return PASS;
 }
-
-

--- a/src/proxymain.c
+++ b/src/proxymain.c
@@ -345,7 +345,6 @@ int MODULEMAINFUNC (int argc, char** argv){
 	"\n"
 	" -iIP ip address or internal interface (clients are expected to connect)\n"
 	" -eIP ip address or external interface (outgoing connection will have this)\n"
-	" -TrFIRST-LAST, -UrFIRST-LAST, -UArFIRST-LAST Linux: local TCP, UDP or UDP ASSOCIATE ranges\n"
 	" -rHOST:PORT Use IP:port for connect back proxy instead of listen port\n"
 	" -RHOST:PORT Use PORT to listen connect back proxy connection to pass data to\n"
 	" -4 Use IPv4 for outgoing connections\n"
@@ -569,35 +568,6 @@ int MODULEMAINFUNC (int argc, char** argv){
 			srv.needuser = 0;
 			if(*(argv[i] + 2)) srv.needuser = atoi(argv[i] + 2);
 			break;
-		 case 'U':
-#ifdef __linux__
-			{
-				char *end;
-				const char *range_arg;
-				unsigned long first, last;
-				uint32_t *range;
-
-				if(argv[i][2] == 'r') {
-					range_arg = argv[i] + 3;
-					range = &srv.udp_local_port_range;
-				}
-				else if(argv[i][2] == 'A' && argv[i][3] == 'r') {
-					range_arg = argv[i] + 4;
-					range = &srv.udp_associate_port_range;
-				}
-				else { error = 1; break; }
-				errno = 0;
-				first = strtoul(range_arg, &end, 10);
-				if(errno || end == range_arg || *end != '-') { error = 1; break; }
-				errno = 0;
-				last = strtoul(end + 1, &end, 10);
-				if(errno || *end || !first || !last || first > last || last > 65535) { error = 1; break; }
-				*range = ((uint32_t)last << 16) | (uint32_t)first;
-			}
-#else
-			error = 1;
-#endif
-			break;
 		 case 'x':
 			srv.nostarttls = 1;
 			break;
@@ -620,27 +590,7 @@ int MODULEMAINFUNC (int argc, char** argv){
 			}
 			break;
 		 case 'T':
-			if(!argv[i][2]) {
-				srv.transparent = 1;
-				break;
-			}
-#ifdef __linux__
-			{
-				char *end;
-				unsigned long first, last;
-
-				if(argv[i][2] != 'r') { error = 1; break; }
-				errno = 0;
-				first = strtoul(argv[i] + 3, &end, 10);
-				if(errno || end == argv[i] + 3 || *end != '-') { error = 1; break; }
-				errno = 0;
-				last = strtoul(end + 1, &end, 10);
-				if(errno || *end || !first || !last || first > last || last > 65535) { error = 1; break; }
-				srv.tcp_local_port_range = ((uint32_t)last << 16) | (uint32_t)first;
-			}
-#else
-			error = 1;
-#endif
+			srv.transparent = 1;
 			break;
 		 case 'S':
 			srv.stacksize = atoi(argv[i]+2);

--- a/src/redirect.c
+++ b/src/redirect.c
@@ -295,6 +295,9 @@ int handleredirect(struct clientparam * param, struct ace * acentry){
 		if(!connected){
 			if(cur->type == R_EXTIP){
 				param->sinsl = cur->addr;
+#ifdef WITH_LOCAL_PORT_RANGE
+				param->local_port_range = cur->local_port_range;
+#endif
 				if(SAISNULL(&param->sinsl) && (*SAFAMILY(&param->sincr) == AF_INET || *SAFAMILY(&param->sincr) == AF_INET6))param->sinsl = param->sincr;
 #ifndef NOIPV6
 				else if(cur->cidr && *SAFAMILY(&param->sinsl) == AF_INET6){

--- a/src/resolve.c
+++ b/src/resolve.c
@@ -60,6 +60,10 @@ uint32_t udpresolve(int af, unsigned char * name, unsigned char * value, uint32_
 	    *SAFAMILY(sinsl) = *SAFAMILY(&nservers[i].addr);
 	}
 	if((sock=so._socket(so.state, SASOCK(sinsl), usetcp?SOCK_STREAM:SOCK_DGRAM, usetcp?IPPROTO_TCP:IPPROTO_UDP)) == INVALID_SOCKET) break;
+	if(param && set_local_port_range(param->srv, sock, (struct sockaddr *)sinsl, usetcp ? LOCAL_PORT_RANGE_TCP : LOCAL_PORT_RANGE_UDP)) {
+		so._closesocket(so.state, sock);
+		break;
+	}
 	if(so._bind(so.state, sock,(struct sockaddr *)sinsl,SASIZE(sinsl))){
 	    so._shutdown(so.state, sock, SHUT_RDWR);
 	    so._closesocket(so.state, sock);

--- a/src/resolve.c
+++ b/src/resolve.c
@@ -60,10 +60,6 @@ uint32_t udpresolve(int af, unsigned char * name, unsigned char * value, uint32_
 	    *SAFAMILY(sinsl) = *SAFAMILY(&nservers[i].addr);
 	}
 	if((sock=so._socket(so.state, SASOCK(sinsl), usetcp?SOCK_STREAM:SOCK_DGRAM, usetcp?IPPROTO_TCP:IPPROTO_UDP)) == INVALID_SOCKET) break;
-	if(param && set_local_port_range(param->srv, sock, (struct sockaddr *)sinsl, usetcp ? LOCAL_PORT_RANGE_TCP : LOCAL_PORT_RANGE_UDP)) {
-		so._closesocket(so.state, sock);
-		break;
-	}
 	if(so._bind(so.state, sock,(struct sockaddr *)sinsl,SASIZE(sinsl))){
 	    so._shutdown(so.state, sock, SHUT_RDWR);
 	    so._closesocket(so.state, sock);

--- a/src/socks.c
+++ b/src/socks.c
@@ -218,6 +218,8 @@ void * sockschild(struct clientparam* param) {
 	if((res = udpbind(param))) {RETURN(res);}
  }
  else if(command == 2) {
+	if(set_local_port_range(param->srv, param->remsock, (struct sockaddr *)&param->sinsl,
+		LOCAL_PORT_RANGE_TCP)) RETURN(12);
 	if(param->srv->so._bind(param->sostate, param->remsock,(struct sockaddr *)&param->sinsl,SASIZE(&param->sinsl))) {
 		*SAPORT(&param->sinsl) = 0;
 		if(param->srv->so._bind(param->sostate, param->remsock,(struct sockaddr *)&param->sinsl,SASIZE(&param->sinsl)))RETURN (12);
@@ -243,6 +245,7 @@ fflush(stderr);
 #endif
 		sin = param->sincl;
 		*SAPORT(&sin) = 0;
+		if(set_local_port_range(param->srv, param->clisock, (struct sockaddr *)&sin, LOCAL_PORT_RANGE_UDP_ASSOCIATE)) {RETURN (12);}
 		if(param->srv->so._bind(param->sostate, param->clisock,(struct sockaddr *)&sin,SASIZE(&sin))) {RETURN (12);}
 		sasize = SASIZE(&sin);
 		param->srv->so._getsockname(param->sostate, param->clisock, (struct sockaddr *)&sin, &sasize);

--- a/src/socks.c
+++ b/src/socks.c
@@ -218,8 +218,9 @@ void * sockschild(struct clientparam* param) {
 	if((res = udpbind(param))) {RETURN(res);}
  }
  else if(command == 2) {
-	if(set_local_port_range(param->srv, param->remsock, (struct sockaddr *)&param->sinsl,
-		LOCAL_PORT_RANGE_TCP)) RETURN(12);
+#ifdef WITH_LOCAL_PORT_RANGE
+	if(set_local_port_range(param, param->remsock, (struct sockaddr *)&param->sinsl)) RETURN(12);
+#endif
 	if(param->srv->so._bind(param->sostate, param->remsock,(struct sockaddr *)&param->sinsl,SASIZE(&param->sinsl))) {
 		*SAPORT(&param->sinsl) = 0;
 		if(param->srv->so._bind(param->sostate, param->remsock,(struct sockaddr *)&param->sinsl,SASIZE(&param->sinsl)))RETURN (12);
@@ -245,7 +246,6 @@ fflush(stderr);
 #endif
 		sin = param->sincl;
 		*SAPORT(&sin) = 0;
-		if(set_local_port_range(param->srv, param->clisock, (struct sockaddr *)&sin, LOCAL_PORT_RANGE_UDP_ASSOCIATE)) {RETURN (12);}
 		if(param->srv->so._bind(param->sostate, param->clisock,(struct sockaddr *)&sin,SASIZE(&sin))) {RETURN (12);}
 		sasize = SASIZE(&sin);
 		param->srv->so._getsockname(param->sostate, param->clisock, (struct sockaddr *)&sin, &sasize);

--- a/src/structures.h
+++ b/src/structures.h
@@ -335,6 +335,9 @@ struct chain {
 	unsigned char * extpass;
 	unsigned short weight;
 	unsigned short cidr;
+#ifdef WITH_LOCAL_PORT_RANGE
+	uint32_t local_port_range;
+#endif
 };
 
 struct period {
@@ -590,9 +593,6 @@ struct srvparam {
 	unsigned char *udpbuf;
 	unsigned char *udpbuf2;
 	int udplen;
-	uint32_t tcp_local_port_range;
-	uint32_t udp_local_port_range;
-	uint32_t udp_associate_port_range;
 };
 
 struct clientparam {
@@ -672,6 +672,9 @@ struct clientparam {
 			maxtrafout64;
 	PROXYSOCKADDRTYPE sincl, sincr;
 	PROXYSOCKADDRTYPE	sinsl, sinsr, req;
+#ifdef WITH_LOCAL_PORT_RANGE
+	uint32_t local_port_range;
+#endif
 
 	uint64_t	statscli64,
 			statssrv64;

--- a/src/structures.h
+++ b/src/structures.h
@@ -590,6 +590,9 @@ struct srvparam {
 	unsigned char *udpbuf;
 	unsigned char *udpbuf2;
 	int udplen;
+	uint32_t tcp_local_port_range;
+	uint32_t udp_local_port_range;
+	uint32_t udp_associate_port_range;
 };
 
 struct clientparam {

--- a/src/udpsockmap.c
+++ b/src/udpsockmap.c
@@ -121,12 +121,14 @@ int udpbind(struct clientparam *param)
 	fcntl(s, F_SETFL, O_NONBLOCK | fcntl(s, F_GETFL));
 #endif
 	param->remsock = s;
-	if (set_local_port_range(param->srv, param->remsock,
-			(struct sockaddr *)&param->sinsl, LOCAL_PORT_RANGE_UDP)) {
+#ifdef WITH_LOCAL_PORT_RANGE
+	if (set_local_port_range(param, param->remsock,
+			(struct sockaddr *)&param->sinsl)) {
 		param->srv->so._closesocket(param->sostate, param->remsock);
 		param->remsock = INVALID_SOCKET;
 		return 12;
 	}
+#endif
 	if (param->srv->so._bind(param->sostate, param->remsock,
 			(struct sockaddr *)&param->sinsl, SASIZE(&param->sinsl))) {
 		*SAPORT(&param->sinsl) = 0;

--- a/src/udpsockmap.c
+++ b/src/udpsockmap.c
@@ -121,6 +121,12 @@ int udpbind(struct clientparam *param)
 	fcntl(s, F_SETFL, O_NONBLOCK | fcntl(s, F_GETFL));
 #endif
 	param->remsock = s;
+	if (set_local_port_range(param->srv, param->remsock,
+			(struct sockaddr *)&param->sinsl, LOCAL_PORT_RANGE_UDP)) {
+		param->srv->so._closesocket(param->sostate, param->remsock);
+		param->remsock = INVALID_SOCKET;
+		return 12;
+	}
 	if (param->srv->so._bind(param->sostate, param->remsock,
 			(struct sockaddr *)&param->sinsl, SASIZE(&param->sinsl))) {
 		*SAPORT(&param->sinsl) = 0;


### PR DESCRIPTION
# Local port ranges through `parent extip`

Adds optional Linux `IP_LOCAL_PORT_RANGE` support without changing global sysctl settings.

## Configuration

The local port range is configured per ACL/connection chain through the existing `parent extip` directive:

```cfg
allow test
parent 1000 extip 192.168.1.10 40020-40030
socks -p1080
```

`FIRST-LAST` is an inclusive IPv4 local-port range. A plain `extip` remains valid without a port argument:

```cfg
parent 1000 extip 192.168.1.10
```

The range is selected only for requests matching that `parent extip` rule. This keeps source-address and source-port selection together and allows different ACLs to use different ranges.

For a chain with a parent proxy:

```cfg
allow test
parent 1000 extip 192.168.1.10 40020-40030
parent 1000 socks5 upstream.example.com 1080
socks -p1080
```

## Build option

The feature is compiled only with `WITH_LOCAL_PORT_RANGE`.

For the Linux Makefile it is enabled by default and can be disabled completely:

```sh
make -f Makefile.Linux LOCAL_PORT_RANGE=true -j2
make -f Makefile.Linux LOCAL_PORT_RANGE=false -j2
```

When disabled, the option parsing, data fields, and socket-level range code are not included in the build.

## Behaviour

- `IP_LOCAL_PORT_RANGE` is set before `bind(2)`.
- The range applies to outgoing IPv4 sockets for requests selected by `parent extip`, including outgoing SOCKS UDP relay sockets.
- DNS resolver traffic deliberately does not inherit this range and continues to use the local resolver path.
- No global `net.ipv4.ip_local_port_range` setting is changed.
- The previous per-service options `-Tr`, `-Ur`, and `-UAr` are removed.

## Requirements and limitations

- Requires Linux kernel 6.3 or newer. In a container, this is the host kernel version.
- Port ranges currently apply only to IPv4 sockets.
- `IP_LOCAL_PORT_RANGE` can narrow, but cannot expand, the global `net.ipv4.ip_local_port_range`.
- Ports reserved through `net.ipv4.ip_local_reserved_ports` remain unavailable.
- The range must be large enough for concurrent connections and sockets in `TIME_WAIT`.
